### PR TITLE
Simplify the image building process

### DIFF
--- a/scripts/ci/kubernetes/docker/Dockerfile
+++ b/scripts/ci/kubernetes/docker/Dockerfile
@@ -15,39 +15,75 @@
 #  specific language governing permissions and limitations      *
 #  under the License.                                           *
 
-FROM ubuntu:16.04
 
-# install deps
-RUN apt-get update -y && apt-get install -y \
-        wget \
-        python-dev \
-        python-pip \
-        libczmq-dev \
-        libcurlpp-dev \
-        curl \
-        libssl-dev \
-        git \
-        inetutils-telnet \
-        bind9utils \
-        zip \
-        unzip \
-    && apt-get clean
+FROM ubuntu:18.04
 
-RUN pip install --upgrade pip
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Since we install vanilla Airflow, we also want to have support for Postgres and Kubernetes
-RUN pip install -U setuptools && \
-    pip install kubernetes && \
-    pip install cryptography && \
-    pip install psycopg2-binary==2.7.4  # I had issues with older versions of psycopg2, just a warning
+RUN apt-get update \
+  && apt-get install -y \
+    curl \
+    wget \
+    git \
+    gnupg2 \
+    llvm \
+    make \
+    zip \
+    unzip \
+    build-essential \
+    bind9utils \
+    inetutils-telnet \
+    libbz2-dev \
+    libcurlpp-dev \
+    libczmq-dev \
+    libffi-dev \
+    liblzma-dev \
+    libncurses5-dev \
+    libncursesw5-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    python-openssl \
+    tk-dev \
+    xz-utils \
+    zlib1g-dev \
+  && apt-get clean
 
-# install airflow
-COPY airflow.tar.gz /tmp/airflow.tar.gz
-RUN pip install --no-use-pep517 /tmp/airflow.tar.gz
+ENV NODE_VERSION "12"
+RUN ["/bin/bash", "-c", "set -o pipefail \
+    && curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x \
+    | bash - \
+    && apt-get install \
+      -y --no-install-recommends \
+      nodejs"]
 
-COPY airflow-test-env-init.sh /tmp/airflow-test-env-init.sh
+ENV PYENV_INSTALLER_GIT_COMMIT=9aac07fad9eabe78ff63632e95bd33eda33b0a12
+RUN ["/bin/bash", "-c", "set -o pipefail \
+    && curl -sSL \
+      https://raw.githubusercontent.com/pyenv/pyenv-installer/${PYENV_INSTALLER_GIT_COMMIT}/bin/pyenv-installer \
+    | bash"]
+ENV PYENV_ROOT /root/.pyenv
+ENV CFLAGS='-O2'
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 
-COPY bootstrap.sh /bootstrap.sh
+ENV PYTHON_VERSION "3.7.3"
+RUN pyenv install ${PYTHON_VERSION} \
+  && pyenv global ${PYTHON_VERSION}
+
+RUN pip install -U \
+  cryptography==2.7 \
+  GitPython==2.1.11 \
+  kubernetes==9.0.0 \
+  setuptools==41.0.1 \
+  psycopg2-binary==2.8.2
+
+COPY . /tmp/airflow
+RUN cd /tmp/airflow \
+  && pip install . \ 
+  && rm -rf www_rbac/node_modules
+
+RUN mv /tmp/airflow/scripts/ci/kubernetes/docker/airflow-test-env-init.sh /tmp/airflow-test-env-init.sh
+RUN mv /tmp/airflow/scripts/ci/kubernetes/docker/bootstrap.sh /bootstrap.sh
 RUN chmod +x /bootstrap.sh
 
 ENTRYPOINT ["/bootstrap.sh"]

--- a/scripts/ci/kubernetes/docker/airflow-test-env-init.sh
+++ b/scripts/ci/kubernetes/docker/airflow-test-env-init.sh
@@ -19,7 +19,7 @@
 
 set -x
 
-cd /usr/local/lib/python2.7/dist-packages/airflow && \
+cd /root/.pyenv/versions/3.7.3/lib/python3.7/site-packages/airflow && \
 cp -R example_dags/* /root/airflow/dags/ && \
 cp -R contrib/example_dags/example_kubernetes_*.py /root/airflow/dags/ && \
 cp -a contrib/example_dags/libs /root/airflow/dags/ && \

--- a/scripts/ci/kubernetes/docker/build.sh
+++ b/scripts/ci/kubernetes/docker/build.sh
@@ -24,22 +24,9 @@ AIRFLOW_ROOT="$DIRNAME/../../../.."
 
 set -e
 
-echo "Airflow directory $AIRFLOW_ROOT"
-echo "Airflow Docker directory $DIRNAME"
-
-if [[ ${PYTHON_VERSION} == '3' ]]; then
-  PYTHON_DOCKER_IMAGE=python:3.6-slim
-else
-  PYTHON_DOCKER_IMAGE=python:2.7-slim
-fi
-
-cd $AIRFLOW_ROOT
-docker run -ti --rm -v ${AIRFLOW_ROOT}:/airflow \
-    -w /airflow ${PYTHON_DOCKER_IMAGE} ./scripts/ci/kubernetes/docker/compile.sh \
-
-sudo rm -rf ${AIRFLOW_ROOT}/airflow/www_rbac/node_modules
-
-echo "Copy distro $AIRFLOW_ROOT/dist/*.tar.gz ${DIRNAME}/airflow.tar.gz"
-cp $AIRFLOW_ROOT/dist/*.tar.gz ${DIRNAME}/airflow.tar.gz
-cd $DIRNAME && docker build --pull $DIRNAME --tag=${IMAGE}:${TAG}
-rm $DIRNAME/airflow.tar.gz
+cd "$AIRFLOW_ROOT"
+docker build . \
+  -f scripts/ci/kubernetes/docker/Dockerfile \
+  --rm \
+  --pull \
+  --tag="${IMAGE}:${TAG}"


### PR DESCRIPTION
The previous build was confusing, especially when it came to Python versions.
Setting PYTHON_VERSION=3 lead to compiling the library in a Python 3 image,
but the Airflow image would still be running Python 2.